### PR TITLE
[flux] exfiltrate managers

### DIFF
--- a/packages/shelter-docs/reference.md
+++ b/packages/shelter-docs/reference.md
@@ -142,6 +142,12 @@ While not likely, it *is possible* that a store you're trying to access has not 
 
 Therefore **it is strongly recommended** to rely on this function (instead of `flux.stores`/`flux.storesFlat`) if you need to access a store as soon as possible, immediately at plugin load.
 
+### `shelter.flux.managers`
+
+Managers are Discord's new way of handling side effects in Flux. They are lazily loaded through a dispatch interceptor.
+
+This contains a list of all managers.
+
 ### `shelter.flux.intercept`
 
 ```ts

--- a/packages/shelter/src/flux.ts
+++ b/packages/shelter/src/flux.ts
@@ -1,4 +1,4 @@
-import { Dispatcher, FluxStore } from "./types";
+import { Dispatcher, FluxManager, FluxStore } from "./types";
 import exfiltrate from "./exfiltrate";
 
 declare global {
@@ -31,6 +31,12 @@ exfiltrate("_dispatchToken", (store: FluxStore) => {
 
   // abusing the "filter" to just steal all the stores
   // but why not?
+  return false;
+});
+
+export const managers: Array<FluxManager> = [];
+exfiltrate("initializedCount", (manager) => {
+  managers.push(manager);
   return false;
 });
 

--- a/packages/shelter/src/types.ts
+++ b/packages/shelter/src/types.ts
@@ -75,6 +75,18 @@ export type FluxStore<T = Record<string, any>> = T & {
   _reactChangeCallbacks: FluxStoreChangeCallbacks;
 };
 
+export type FluxManager<T = unknown> = T & {
+  initializedCount: number;
+  actions: Record<string, Function>;
+  stores: Map<FluxStore, Function>;
+
+  initialize: () => void;
+  terminate: (force: boolean) => void;
+
+  _initialize: () => void;
+  _terminate: () => void;
+};
+
 // TODO: Test if these are all correct.
 export interface HTTPRequest {
   url: string;


### PR DESCRIPTION
Managers are Discord's new way of handling side effects in Flux. They are lazily loaded through a dispatch interceptor.