### PR TITLE
[UI] add slider component

### DIFF
--- a/packages/shelter-ui/src/index.tsx
+++ b/packages/shelter-ui/src/index.tsx
@@ -14,6 +14,7 @@ export * from "./errorboundary";
 export * from "./toasts";
 export * from "./focusring";
 export * from "./tooltip";
+export * from "./slider";
 
 export const Text: Component<JSX.HTMLAttributes<HTMLSpanElement>> = (props) => (
   <span

--- a/packages/shelter-ui/src/slider.tsx
+++ b/packages/shelter-ui/src/slider.tsx
@@ -1,9 +1,6 @@
 import { Component, JSX } from "solid-js";
-import { css, classes } from "./Slider.tsx.scss";
-
-const {
-  ui: { injectCss },
-} = shelter;
+import { css, classes } from "./slider.tsx.scss";
+import { injectCss } from "./util";
 
 let injectedCss = false;
 
@@ -12,10 +9,10 @@ export const Slider: Component<{
   max: number;
   // These are the little labelled ticks on the slider
   steps?: string[];
-  step?: number;
+  step?: number | "any";
   class?: string;
   style?: JSX.CSSProperties;
-  onInput?(e): void;
+  onInput?(e: number): void;
   value?: number;
 }> = (props) => {
   if (!injectedCss) {
@@ -29,7 +26,7 @@ export const Slider: Component<{
         type="range"
         min={props.min}
         max={props.max}
-        step={props.step}
+        step={props.step ?? "any"}
         class={classes.srange}
         value={props.value ? props.value : props.min}
         style={
@@ -38,7 +35,7 @@ export const Slider: Component<{
             "--upper-half": `${((props.value - props.min) / (props.max - props.min)) * 100}%`,
           } as JSX.CSSProperties
         }
-        onInput={(e) => props.onInput?.((e.target as HTMLInputElement).value)}
+        onInput={(e) => props.onInput?.(parseFloat((e.target as HTMLInputElement).value))}
       />
       <div class={classes.sticks}>
         {props.steps?.map((t) => (

--- a/packages/shelter-ui/src/slider.tsx
+++ b/packages/shelter-ui/src/slider.tsx
@@ -1,0 +1,53 @@
+import { Component, JSX } from "solid-js";
+import { css, classes } from "./Slider.tsx.scss";
+
+const {
+  ui: { injectCss },
+} = shelter;
+
+let injectedCss = false;
+
+export const Slider: Component<{
+  min: number;
+  max: number;
+  // These are the little labelled ticks on the slider
+  steps?: string[];
+  step?: number;
+  class?: string;
+  style?: JSX.CSSProperties;
+  onInput?(e): void;
+  value?: number;
+}> = (props) => {
+  if (!injectedCss) {
+    injectedCss = true;
+    injectCss(css);
+  }
+
+  return (
+    <div class={classes.scontainer}>
+      <input
+        type="range"
+        min={props.min}
+        max={props.max}
+        step={props.step}
+        class={classes.srange}
+        value={props.value ? props.value : props.min}
+        style={
+          {
+            ...props.style,
+            "--upper-half": `${((props.value - props.min) / (props.max - props.min)) * 100}%`,
+          } as JSX.CSSProperties
+        }
+        onInput={(e) => props.onInput?.((e.target as HTMLInputElement).value)}
+      />
+      <div class={classes.sticks}>
+        {props.steps?.map((t) => (
+          <div class={classes.stick}>
+            <span>{t}</span>
+            <div class={classes.stickline}></div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/packages/shelter-ui/src/slider.tsx.scss
+++ b/packages/shelter-ui/src/slider.tsx.scss
@@ -1,0 +1,147 @@
+.scontainer {
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  width: 100%;
+  margin-bottom: 16px;
+
+  height: 54px;
+
+  font-size: 10px;
+  color: var(--header-secondary);
+}
+
+.srange {
+  appearance: none;
+  -webkit-appearance: none;
+
+  background: transparent;
+  cursor: pointer;
+
+  width: 100%;
+
+  --upper-half: 0%;
+
+  z-index: 2;
+
+  /* This CSS is horrifically long but apparently they cannot be comma-separated */
+  &::-ms-track {
+    appearance: none;
+    -webkit-appearance: none;
+
+    background: linear-gradient(to right, var(--brand-experiment) var(--upper-half), var(--brand-experiment) var(--upper-half), var(--primary-500) var(--upper-half), var(--primary-500) 100%);
+    height: 8px;
+
+    border-radius: 3px;
+  }
+
+  &::-webkit-slider-runnable-track {
+    appearance: none;
+    -webkit-appearance: none;
+
+    background: linear-gradient(to right, var(--brand-experiment) var(--upper-half), var(--brand-experiment) var(--upper-half), var(--primary-500) var(--upper-half), var(--primary-500) 100%);
+    height: 8px;
+
+    border-radius: 3px;
+  }
+
+  &::-moz-range-track {
+    appearance: none;
+    -webkit-appearance: none;
+
+    background: linear-gradient(to right, var(--brand-experiment) var(--upper-half), var(--brand-experiment) var(--upper-half), var(--primary-500) var(--upper-half), var(--primary-500) 100%);
+    height: 8px;
+
+    border-radius: 3px;
+  }
+
+  &::-ms-thumb {
+    appearance: none;
+    -webkit-appearance: none;
+
+    top: 50%;
+
+    height: 24px;
+    width: 10px;
+
+    background-color: var(--white-500);
+
+    border: 1px solid var(--primary-200);
+    border-radius: 3px;
+
+    cursor: ew-resize;
+  }
+
+  &::-webkit-slider-thumb {
+    appearance: none;
+    -webkit-appearance: none;
+
+    top: 50%;
+
+    height: 24px;
+    width: 10px;
+
+    background-color: var(--white-500);
+
+    margin-top: calc((8px / 2) - (24px / 2));
+
+    border: 1px solid var(--primary-200);
+    border-radius: 3px;
+
+    cursor: ew-resize;
+  }
+
+  &::-moz-range-thumb {
+    appearance: none;
+    -webkit-appearance: none;
+
+    top: 50%;
+
+    height: 24px;
+    width: 10px;
+
+    background-color: var(--white-500);
+
+    border: 1px solid var(--primary-200);
+    border-radius: 3px;
+
+    cursor: ew-resize;
+  }
+}
+
+.sticks {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+
+  top: 0;
+  left: 0;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  pointer-events: none;
+  z-index: 1;
+}
+
+.stick {
+  height: 100%;
+  z-index: 1;
+
+  display:flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+
+  width: 12px;
+}
+
+.stickline {
+  width: 1px;
+  margin-top: 6px;
+  height: 40%;
+
+  background-color: var(--primary-500);
+}

--- a/packages/shelter-ui/src/slider.tsx.scss
+++ b/packages/shelter-ui/src/slider.tsx.scss
@@ -25,38 +25,22 @@
 
   z-index: 2;
 
-  /* This CSS is horrifically long but apparently they cannot be comma-separated */
-  &::-ms-track {
+  --track-bg: var(--primary-500);
+  :global(.theme-light) & {
+    --track-bg: var(--primary-200)
+  }
+
+  @mixin track {
     appearance: none;
     -webkit-appearance: none;
 
-    background: linear-gradient(to right, var(--brand-experiment) var(--upper-half), var(--brand-experiment) var(--upper-half), var(--primary-500) var(--upper-half), var(--primary-500) 100%);
+    background: linear-gradient(to right, var(--brand-experiment) var(--upper-half), var(--brand-experiment) var(--upper-half), var(--track-bg) var(--upper-half), var(--track-bg) 100%);
     height: 8px;
 
     border-radius: 3px;
   }
 
-  &::-webkit-slider-runnable-track {
-    appearance: none;
-    -webkit-appearance: none;
-
-    background: linear-gradient(to right, var(--brand-experiment) var(--upper-half), var(--brand-experiment) var(--upper-half), var(--primary-500) var(--upper-half), var(--primary-500) 100%);
-    height: 8px;
-
-    border-radius: 3px;
-  }
-
-  &::-moz-range-track {
-    appearance: none;
-    -webkit-appearance: none;
-
-    background: linear-gradient(to right, var(--brand-experiment) var(--upper-half), var(--brand-experiment) var(--upper-half), var(--primary-500) var(--upper-half), var(--primary-500) 100%);
-    height: 8px;
-
-    border-radius: 3px;
-  }
-
-  &::-ms-thumb {
+  @mixin thumb {
     appearance: none;
     -webkit-appearance: none;
 
@@ -71,42 +55,18 @@
     border-radius: 3px;
 
     cursor: ew-resize;
+
+    box-shadow: 0 3px 1px 0 hsl(var(--black-500-hsl)/5%),0 2px 2px 0 hsl(var(--black-500-hsl)/.1),0 3px 3px 0 hsl(var(--black-500-hsl)/5%);
   }
 
+  &::-ms-track { @include track; }
+  &::-webkit-slider-runnable-track { @include track; }
+  &::-moz-range-track { @include track; }
+  &::-ms-thumb { @include thumb; }
+  &::-moz-range-thumb { @include thumb; }
   &::-webkit-slider-thumb {
-    appearance: none;
-    -webkit-appearance: none;
-
-    top: 50%;
-
-    height: 24px;
-    width: 10px;
-
-    background-color: var(--white-500);
-
+    @include thumb;
     margin-top: calc((8px / 2) - (24px / 2));
-
-    border: 1px solid var(--primary-200);
-    border-radius: 3px;
-
-    cursor: ew-resize;
-  }
-
-  &::-moz-range-thumb {
-    appearance: none;
-    -webkit-appearance: none;
-
-    top: 50%;
-
-    height: 24px;
-    width: 10px;
-
-    background-color: var(--white-500);
-
-    border: 1px solid var(--primary-200);
-    border-radius: 3px;
-
-    cursor: ew-resize;
   }
 }
 


### PR DESCRIPTION
Needed to recreate the Discord slider for a project, thought it might be something worth having the `shelter-ui` package :)

Tried to replicate existing code style but feel free to let me know if I did something weird. The CSS looks kinda yucky because I can't comma-seperate the selectors (at least, [so I've heard/read](https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/)).

\*I'm also working on recreating the Discord select list, that'll be a separate PR ofc

Preview:

https://github.com/uwu/shelter/assets/25207995/3d133b64-8da8-410d-863c-84625fc3ccad

Which was made with this code:
```tsx
<Slider
  min={50}
  max={125}
  steps={
    Array.from(Array(16).keys()).map(i => (i * 5 + 50) + '%')
  }
  step={5}
  value={settings().zoom}
  onInput={(v) => {}}
/>
```