### PR TITLE
Exfiltrate React using `useId` instead of `useRef`

### DIFF
--- a/packages/shelter/src/react.ts
+++ b/packages/shelter/src/react.ts
@@ -2,5 +2,5 @@ import exfiltrate from "./exfiltrate";
 
 export let React, ReactDOM;
 
-exfiltrate("useRef").then((v) => (React = v));
+exfiltrate("useId").then((v) => (React = v));
 exfiltrate("findDOMNode").then((v) => (ReactDOM = v));


### PR DESCRIPTION
Recently, due to an update to... something, I assume, a project of mine has been having trouble rendering Shelter-based elements while another client mod is loaded. This is kinda bad (but not Shelter's fault! Just a wonky incompatibility) since the whole frontend-backend communication runs via Shelter :P

After some testing, I boiled it down to the fact that the other client mod would call `defineProperty` to define `useRef`, which is how Shelter finds `React`. For some reason, the object that was getting `useRef` defined also had most properties set to `undefined`, which would cause calls to things like `createElement` from Shelter plugins to fail.

I came to this solution by making an assumption that, while `useId` will probably always exist on Discord's `React`, other client mods will likely never have a reason to redefine it themselves, meaning the exfiltration has a much lower chance of picking up an object it's not supposed to.