### PR TITLE
lune/dev: explicitly bind to IPv4 loopback

### DIFF
--- a/packages/lune/src/commands/dev.ts
+++ b/packages/lune/src/commands/dev.ts
@@ -16,7 +16,7 @@ let current: { manifest: any; js: string };
 
 const broadcastList = new Set<() => Promise<void>>();
 function startWs() {
-  const wsServer = new WebSocketServer({ port: 1211 });
+  const wsServer = new WebSocketServer({ host: "127.0.0.1", port: 1211 });
   wsServer.on("connection", (sockets) => {
     const broadcast = () =>
       new Promise<void>((res, rej) => {


### PR DESCRIPTION
Currently the HTTP server is started with an explicit host and the WebSocket Server is left to pick its own. This can result in IPv6 being preferred on the WebSocket server side when the WebSocket client points to IPv4 loopback explicitly.

This change fixes that by explicitly specifying the IPv4 loopback address. Alternate possible fixes include using `localhost` everywhere which makes no assumption about the IPv4 or IPv6 capabilities of the device (though requires `localhost` to point to the loopback, which mostly should be the case).