### PR TITLE
fix: readlink returns an empty string if target folder is not syslinked

### DIFF
--- a/injectors/linux-package-managers/scripts/find-resources.sh
+++ b/injectors/linux-package-managers/scripts/find-resources.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-echo $(readlink $(command -v $1) | rev | cut -d/ -f2- | rev)/resources
+echo $(readlink -f $(command -v $1) | rev | cut -d/ -f2- | rev)/resources


### PR DESCRIPTION
Running ``readlink`` on a folder that isn't syslinked returns an empty string.
The ``-f`` option will resolve that.