### PR TITLE
wip: fix settings injection for refresh and add getProps

### DIFF
--- a/packages/shelter-docs/docs/reference.md
+++ b/packages/shelter-docs/docs/reference.md
@@ -343,6 +343,14 @@ Gets a React *fiber* from a DOM node.
 The fiber contains information about the state of the React element that Discord used to render the UI,
 and can be useful to extract, for example, message objects from the DOM.
 
+### `shelter.util.getProps`
+
+```ts
+function getProps(node: DOMNode): any
+```
+
+Gets the React props from a DOM node.
+
 ### `shelter.util.getFiberOwner`
 
 ```ts

--- a/packages/shelter/src/settings.tsx
+++ b/packages/shelter/src/settings.tsx
@@ -1,7 +1,7 @@
 // Injects a section into user settings
 
 import { getDispatcher } from "./flux";
-import { awaitDispatch, getFiber, getFiberOwner, reactFiberWalker } from "./util";
+import { getFiber, getFiberOwner, getProps, reactFiberWalker } from "./util";
 import { observe } from "./observer";
 import { Component } from "solid-js";
 import { SolidInReactBridge } from "./bridges";
@@ -24,8 +24,8 @@ let injectorSections: SettingsSection[] = [];
 
 let externalSections: SettingsSection[] = [];
 
-const generatePredicateSections = () =>
-  [...injectorSections, ...shelterSections, ...externalSections].map((s) => {
+function legacyGeneratePredicateSections() {
+  return [...injectorSections, ...shelterSections, ...externalSections].map((s) => {
     switch (s[0]) {
       case "divider":
         return { section: "DIVIDER" };
@@ -43,13 +43,111 @@ const generatePredicateSections = () =>
         };
     }
   });
+}
+
+const LAYOUT_PREFIX = "shelter";
+
+function internalGenerateLayoutAndMappings(root: any, sectionName: string, sectionItem: SettingsSection) {
+  const [, id, name, pane] = sectionItem;
+
+  const layoutSection = {
+    key: `${LAYOUT_PREFIX}_${sectionName.toLowerCase()}_section`,
+    layout: [],
+    parent: root,
+    type: 1,
+    useLabel: () => sectionName,
+  };
+
+  const layoutSidebarItem = {
+    icon: () => {},
+    key: `${LAYOUT_PREFIX}_${id}_sidebar_item`,
+    trailing: { type: 1 },
+    layout: [],
+    legacySearchKey: `${LAYOUT_PREFIX}_${id.toUpperCase()}`,
+    parent: layoutSection,
+    type: 2,
+    useTitle: () => name,
+  };
+
+  const layoutPanel = {
+    key: `${LAYOUT_PREFIX}_${id}_panel`,
+    layout: [],
+    parent: layoutSidebarItem,
+    type: 3,
+    useTitle: () => name,
+  };
+
+  const layoutPane = {
+    key: `${LAYOUT_PREFIX}_${id}_pane`,
+    layout: [],
+    parent: layoutPanel,
+    render: () => <SolidInReactBridge comp={pane} />,
+    type: 4,
+    useTitle: () => name,
+  };
+
+  layoutPanel.layout.push(layoutPane);
+  layoutSidebarItem.layout.push(layoutPanel);
+  layoutSection.layout.push(layoutSidebarItem);
+
+  const mapping = {
+    [layoutSection.key]: {
+      node: layoutSection,
+    },
+    [layoutSidebarItem.key]: {
+      node: layoutSidebarItem,
+      targetPanel: layoutPanel,
+    },
+    [layoutPanel.key]: {
+      node: layoutPanel,
+      targetPanel: layoutPanel,
+    },
+    [layoutPane.key]: {
+      node: layoutPane,
+      targetPanel: layoutPanel,
+    },
+  };
+
+  return { layout: layoutSection, mapping };
+}
+
+function generateLayoutsAndMappings(root: any) {
+  const layouts = [];
+  const mappings = {};
+  let currentSectionHeader = "Unknown";
+
+  for (const s of [...injectorSections, ...shelterSections, ...externalSections]) {
+    if (s[0] === "header") {
+      currentSectionHeader = s[1];
+      continue;
+    }
+
+    if (s[0] === "section") {
+      const { layout, mapping } = internalGenerateLayoutAndMappings(root, currentSectionHeader, s);
+      layouts.push(layout);
+      Object.assign(mappings, mapping);
+      continue;
+    }
+  }
+
+  return { layouts, mappings };
+}
 
 export async function initSettings() {
+  const [uninjectLegacySettings, uninjectSettings] = await Promise.all([legacyInjectSettings(), injectSettings()]);
+
+  return () => {
+    uninjectLegacySettings();
+    uninjectSettings();
+  };
+}
+
+async function legacyInjectSettings() {
   const FluxDispatcher = await getDispatcher();
 
   let canceled = false;
-  let unpatch;
-  let stopPrevious;
+  let unpatch: () => void;
+  let stopPrevious: () => void;
 
   const cb = async () => {
     stopPrevious?.();
@@ -89,11 +187,11 @@ export async function initSettings() {
       if (changelogIdx === -1) return;
 
       // -1 to go ahead of the divider above it
-      ret.splice(changelogIdx - 1, 0, ...generatePredicateSections());
+      ret.splice(changelogIdx - 1, 0, ...legacyGeneratePredicateSections());
     });
 
     // trigger rerender for first load
-    rerenderSidebar();
+    legacyRerenderSidebar();
 
     FluxDispatcher.unsubscribe("USER_SETTINGS_MODAL_OPEN", cb);
   };
@@ -107,7 +205,96 @@ export async function initSettings() {
   };
 }
 
-function rerenderSidebar() {
+async function injectSettings() {
+  const FluxDispatcher = await getDispatcher();
+
+  let canceled = false;
+  let stopPrevious: () => void;
+
+  const cb = async () => {
+    stopPrevious?.();
+
+    // wait for lazy loading on initial user settings open
+    const sidebar = await new Promise<Element | void>((res) => {
+      const trackCallback = (p: any) => {
+        if (p.event === "settings_pane_viewed" && p.properties.settings_type === "user") {
+          res(document.querySelector("[data-list-id=settings-sidebar]"));
+        }
+      };
+      FluxDispatcher.subscribe("TRACK", trackCallback);
+
+      // fallback in case track dispatches are disabled (e.g. BD's DoNotTrack)
+      const unobserve = observe("[data-list-id=settings-sidebar]", res);
+      setTimeout(unobserve, 3_000);
+
+      stopPrevious = () => {
+        FluxDispatcher.unsubscribe("TRACK", trackCallback);
+        unobserve();
+        res();
+      };
+    });
+
+    if (!sidebar || canceled) return;
+
+    const sidebarDirectoryFiber = reactFiberWalker(
+      getFiber(document.querySelector("[data-list-id=settings-sidebar]")),
+      "directory",
+      true,
+    );
+
+    // this function gets assigned by something else later on. That's why patcher wouldn't work here.
+    const originalType = sidebarDirectoryFiber.type as Function;
+    Object.defineProperty(sidebarDirectoryFiber, "type", {
+      get: () =>
+        function () {
+          const settings = arguments[0];
+
+          const { layouts, mappings } = generateLayoutsAndMappings(settings.root);
+
+          for (const [key, val] of Object.entries(mappings)) {
+            settings.directory.map.set(key, val);
+          }
+
+          // remove shelter sections that were unregistered
+          settings.root.layout = settings.root.layout.filter(
+            ({ key }) => !key.startsWith(LAYOUT_PREFIX) || layouts.some((other) => other.key === key),
+          );
+
+          // ignore duplicates
+          const filteredLayouts = layouts.filter(({ key }) => !settings.root.layout.some((other) => other.key === key));
+
+          // insert layout after activity section, otherwise before the log out button
+          const activityIndex = settings.root.layout.findIndex(({ key }) => key === "activity_section");
+          const insertIndex = activityIndex === -1 ? settings.root.layout.length - 1 : activityIndex + 1;
+
+          settings.root.layout.splice(insertIndex, 0, ...filteredLayouts);
+
+          return originalType.apply(this, arguments);
+        },
+      set: () => {},
+    });
+
+    refreshSidebarSections();
+  };
+
+  FluxDispatcher.subscribe("USER_SETTINGS_MODAL_OPEN", cb);
+
+  return () => {
+    FluxDispatcher.unsubscribe("USER_SETTINGS_MODAL_OPEN", cb);
+    canceled = true;
+  };
+}
+
+function refreshSidebarSections() {
+  document.querySelectorAll("[class^=searchBarContainer] input").forEach((searchInput) => {
+    const props = getProps(searchInput);
+    const oldValue = props.value;
+    props.onChange({ currentTarget: { value: " " } });
+    setTimeout(() => props.onChange({ currentTarget: { value: oldValue } }));
+  });
+}
+
+function legacyRerenderSidebar() {
   const sidebarParent = document.querySelector(`nav[class^="sidebar"]`);
   getFiberOwner(sidebarParent)?.forceUpdate();
 }
@@ -116,14 +303,16 @@ function registerSectionInternal(sec: SettingsSection, injector: boolean) {
   const secs = injector ? injectorSections : externalSections;
 
   secs.push(sec);
-  rerenderSidebar();
+  legacyRerenderSidebar();
+  refreshSidebarSections();
 
   return () => {
     const idx = secs.indexOf(sec);
     if (idx === -1) return;
 
     secs.splice(idx, 1);
-    rerenderSidebar();
+    legacyRerenderSidebar();
+    refreshSidebarSections();
   };
 }
 

--- a/packages/shelter/src/util/index.ts
+++ b/packages/shelter/src/util/index.ts
@@ -17,6 +17,12 @@ export const getFiber = (n: Element): Fiber => {
   return n[(fiberKey = Object.keys(n).find((key) => key.startsWith("__reactFiber$")) ?? fiberKey)];
 };
 
+let propsKey: string;
+export const getProps = (n: Element): any => {
+  if (propsKey && n[propsKey]) return n[propsKey];
+  return n[(propsKey = Object.keys(n).find((key) => key.startsWith("__reactProps$")) ?? propsKey)];
+};
+
 export const getFiberOwner = (n: Element | Fiber): undefined | null | FiberOwner => {
   const filter = ({ stateNode }: Fiber) => stateNode && !(stateNode instanceof Element);
   return reactFiberWalker(n instanceof Element ? getFiber(n) : n, filter, true)?.stateNode as


### PR DESCRIPTION
TODO:
- [ ] add icons for shelter pages
- [ ] allow `extras` like badge count and icon for injector/extra pages [ref](https://shelter.uwu.network/reference#shelter-settings-registersection)
- [ ] fix pages with the same section header each getting their own section. This can be tested by adding snazzy shelter