### PR TITLE
Extend Slider tick API to support explicit tick positions

### DIFF
--- a/packages/shelter-docs/docs/ui.md
+++ b/packages/shelter-docs/docs/ui.md
@@ -468,7 +468,7 @@ The `counter` prop shows a character counter.
 solid.Component<{
   min: number,
   max: number,
-  tick?: boolean | number,
+  tick?: boolean | number | number[],
   step?: number | "any",
   class?: string,
   style?: JSX.CSSProperties,
@@ -485,8 +485,8 @@ Set `min` and `max` as needed.
 
 `step` controls the size of the actual steps the slider is locked to.
 
-`tick` controls the spacing between ticks to show. This must be an even divisor of (min - max), but plans are to fix this
-in the future.
+`tick` controls the ticks shown below the slider. If `true` or a number, it sets the spacing between evenly distributed ticks.
+If an array of numbers is passed, each number is used as an exact tick position instead.
 
 If `tick` is not passed, no ticks show.
 

--- a/packages/shelter-ui-test/src/App.tsx
+++ b/packages/shelter-ui-test/src/App.tsx
@@ -198,6 +198,10 @@ export default function App() {
       <p>Boolean tick (uses step):</p>
       <SU.Slider min={0} max={100} step={10} tick={true} value={50} onInput={setSlide} />
 
+      <h3>Slider with non-zero min/max</h3>
+      <p>min=50, max=125, tick=25 (should show 50, 75, 100, 125)</p>
+      <SU.Slider min={50} max={125} step={5} tick={25} value={slide()} onInput={setSlide} />
+
       <h2>Switch</h2>
       <p>on: {toggle() ? "yes" : "no"}</p>
       <SU.Switch onChange={setToggle} checked={toggle()} />

--- a/packages/shelter-ui-test/src/App.tsx
+++ b/packages/shelter-ui-test/src/App.tsx
@@ -190,6 +190,14 @@ export default function App() {
       <p>value: {slide()}</p>
       <SU.Slider min={0} max={120} step={5} tick={20} value={slide()} onInput={setSlide} />
 
+      <h3>Slider with array ticks</h3>
+      <p>Custom tick positions: [0, 15, 35, 60, 85, 120]</p>
+      <SU.Slider min={0} max={120} step={5} tick={[0, 15, 35, 60, 85, 120]} value={slide()} onInput={setSlide} />
+
+      <h3>Slider with boolean ticks</h3>
+      <p>Boolean tick (uses step):</p>
+      <SU.Slider min={0} max={100} step={10} tick={true} value={50} onInput={setSlide} />
+
       <h2>Switch</h2>
       <p>on: {toggle() ? "yes" : "no"}</p>
       <SU.Switch onChange={setToggle} checked={toggle()} />

--- a/packages/shelter-ui/src/slider.tsx
+++ b/packages/shelter-ui/src/slider.tsx
@@ -39,7 +39,7 @@ export const Slider: NativeExtendingComponent<SliderProps, JSX.InputHTMLAttribut
 
     const spacing = other.tick === true ? other.step : other.tick;
     return Object.keys(Array(Math.floor((other.max - other.min) / spacing) + 1).fill(0)).map(
-      (v) => parseInt(v) * spacing,
+      (v) => other.min + parseInt(v) * spacing,
     );
   };
 

--- a/packages/shelter-ui/src/slider.tsx
+++ b/packages/shelter-ui/src/slider.tsx
@@ -8,7 +8,7 @@ type SliderProps = {
 
   min: number;
   max: number;
-  tick?: boolean | number;
+  tick?: boolean | number | number[];
   step?: number | "any";
   value?: number;
 
@@ -32,6 +32,7 @@ export const Slider: NativeExtendingComponent<SliderProps, JSX.InputHTMLAttribut
   );
 
   const ticks = () => {
+    if (Array.isArray(other.tick)) return other.tick;
     if (!other.tick || typeof other.step !== "number") {
       return [];
     }
@@ -56,15 +57,14 @@ export const Slider: NativeExtendingComponent<SliderProps, JSX.InputHTMLAttribut
         }
         onInput={(e) => local.onInput?.(parseFloat((e.target as HTMLInputElement).value))}
       />
-      <div
-        class={classes.sticks}
-        style={{
-          "margin-left": `-${ticks().length / 2}px`,
-          width: `calc(100% + ${ticks().length}px)`,
-        }}
-      >
+      <div class={classes.sticks}>
         {ticks().map((t) => (
-          <div class={classes.stick}>
+          <div
+            class={classes.stick}
+            style={{
+              left: `${((t - other.min) / (other.max - other.min)) * 100}%`,
+            }}
+          >
             <span class={classes.sticktext}>{t}</span>
             <div class={classes.stickline}></div>
           </div>

--- a/packages/shelter-ui/src/slider.tsx.scss
+++ b/packages/shelter-ui/src/slider.tsx.scss
@@ -84,11 +84,8 @@
 }
 
 .sticks {
-  display: flex;
   z-index: 1;
   position: absolute;
-  align-items: center;
-  justify-content: space-between;
   width: 100%;
   height: 100%;
   pointer-events: none;
@@ -97,11 +94,13 @@
 .stick {
   display: flex;
   z-index: 1;
+  position: absolute;
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
   width: 24px;
   height: 100%;
+  transform: translateX(-50%);
 }
 
 .sticktext {


### PR DESCRIPTION
# Hello !

This PR introduces support for explicit tick positions in the `Slider` component by allowing the `tick` prop to accept an array of numbers, in addition to its current boolean and numeric forms.

## Motivation

Right now, ticks can only be generated in a uniform way, either based on `step` or a fixed spacing value. That works well for linear scales, but it becomes limiting when the UI needs to reflect meaningful, non-uniform values.

A concrete example is a zoom slider, where relevant breakpoints might be:

50% 75% 100% 125%

These values don’t naturally map to a regular interval, and using the current API requires building a custom overlay outside of the component. That approach works, but it duplicates logic and makes the UI harder to maintain.

This use case came up in practice [here](https://github.com/SpikeHD/shelter-plugins/pull/91#issue-4361627429).

## What this changes

The `tick` prop now accepts:

* `boolean` to generate ticks from `step` (unchanged)
* `number` to define a fixed spacing (unchanged)
* `number[]` to define explicit tick positions (new)

Example:

```tsx
<Slider
  min={50}
  max={125}
  step={5}
  tick={[50, 75, 100, 125]}
/>
```

## Why this approach

This keeps the API small and consistent while making it more flexible. It doesn’t introduce a new prop or change existing behavior, it just extends what’s already there.

It also removes the need for external tick rendering in cases where the scale is not strictly linear, which helps keep UI logic inside the component where it belongs.

## Notes

* Existing usages are fully preserved
* Tick positioning is computed relative to `min` and `max`
* The `tick` prop is no longer forwarded to the underlying input element

Let me know if you’d prefer a different API shape, happy to adjust.
