### PR TITLE
fix: start tick marks from min value in slider

### DIFF
--- a/packages/shelter-ui-test/src/App.tsx
+++ b/packages/shelter-ui-test/src/App.tsx
@@ -188,7 +188,7 @@ export default function App() {
 
       <h2>Slider</h2>
       <p>value: {slide()}</p>
-      <SU.Slider min={0} max={120} step={5} tick={20} value={slide()} onInput={setSlide} />
+      <SU.Slider min={50} max={125} step={5} tick={25} value={slide()} onInput={setSlide} />
 
       <h2>Switch</h2>
       <p>on: {toggle() ? "yes" : "no"}</p>

--- a/packages/shelter-ui/src/slider.tsx
+++ b/packages/shelter-ui/src/slider.tsx
@@ -38,7 +38,7 @@ export const Slider: NativeExtendingComponent<SliderProps, JSX.InputHTMLAttribut
 
     const spacing = other.tick === true ? other.step : other.tick;
     return Object.keys(Array(Math.floor((other.max - other.min) / spacing) + 1).fill(0)).map(
-      (v) => parseInt(v) * spacing,
+      (v) => other.min + parseInt(v) * spacing,
     );
   };
 


### PR DESCRIPTION
# Hello!
This PR solves issue #70 by starting the tick marks rendering from the min value. 